### PR TITLE
[TASK] Add extension key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
     "cgl-fix": [
       "php-cs-fixer fix -v --using-cache false"
     ]
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "pwa_manifest"
+    }
   }
 }


### PR DESCRIPTION
Is this extension used in composer-based projects, a warning is currently printed during updates.

> Not providing this property will emit a deprecation notice and will fail in future versions.