### PR TITLE
[FEATURE][UPDATE]Add EXT: file Path, use dynamic path for serviceWorker.register

### DIFF
--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 
 namespace FriendsOfTYPO3\PwaManifest\Service;
 
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\Config\Resource\FileResource;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Resource\Exception\InvalidFileException;
+use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
+use TYPO3\CMS\Core\Resource\Folder;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use function array_filter;
 
 /***
  *
@@ -26,23 +35,31 @@ use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
  */
 class ConfigurationService
 {
+    private ?ServerRequestInterface $request = null;
+
     /**
+     * @param string $content
+     * @param array $conf
+     * @param ServerRequestInterface $request
      * @return string
+     * @throws InvalidFileException
+     * @throws ResourceDoesNotExistException
      */
-    public function provideConfiguration(): string
+    public function provideConfiguration(string $content, array $conf, ServerRequestInterface $request): string
     {
+        $this->request = $request;
         $siteConfiguration = $this->getSite()->getConfiguration();
         $settings = [
             'short_name' => $siteConfiguration['manifestShortName'] ?? '',
             'name' => $siteConfiguration['manifestName'] ?? '',
             'icons' => [
                 [
-                    'src' => $siteConfiguration['manifestSmallIconSource'] ?? '',
+                    'src' => $this->getPathForSrc($siteConfiguration['manifestSmallIconSource'] ?? ''),
                     'type' => $siteConfiguration['manifestSmallIconType'] ?? '',
                     'sizes' => $siteConfiguration['manifestSmallIconSizes'] ?? '',
                 ],
                 [
-                    'src' => $siteConfiguration['manifestBigIconSource'] ?? '',
+                    'src' => $this->getPathForSrc($siteConfiguration['manifestBigIconSource'] ?? ''),
                     'type' => $siteConfiguration['manifestBigIconType'] ?? '',
                     'sizes' => $siteConfiguration['manifestBigIconSizes'] ?? '',
                 ]
@@ -58,6 +75,42 @@ class ConfigurationService
         return json_encode($settings);
     }
 
+    /**
+     * @return Site
+     */
+    protected function getSite(): Site
+    {
+        return $this->request->getAttribute('site');
+    }
+
+    /**
+     * @param string $src
+     * @return string
+     * @throws InvalidFileException
+     * @throws ResourceDoesNotExistException
+     */
+    protected function getPathForSrc(string $src): string
+    {
+        // If the src is an extension path, we need to get the public path
+        if (PathUtility::isExtensionPath($src)) {
+            return PathUtility::getPublicResourceWebPath($src);
+        }
+        // If not an extension path, we need to get the public path of the file
+        $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
+        $file = $resourceFactory->retrieveFileOrFolderObject($src);
+        // If the file is not found , we return an empty string
+        if($file === null || $file instanceof Folder) {
+            return '';
+        }
+        return $file->getPublicUrl();
+    }
+
+    /**
+     * @param array $siteConfiguration
+     * @return array
+     * @throws InvalidFileException
+     * @throws ResourceDoesNotExistException
+     */
     protected function getShortcutsConfiguration(array $siteConfiguration): array
     {
         $contentObject = GeneralUtility::makeInstance(ContentObjectRenderer::class);
@@ -67,13 +120,13 @@ class ConfigurationService
                 ($siteConfiguration["manifestShortcuts{$i}Name"] ?? '') !== '' &&
                 ($siteConfiguration["manifestShortcuts{$i}Url"] ?? '') !== ''
             ) {
-                $shortcuts[] = \array_filter([
+                $shortcuts[] = array_filter([
                     'name' => $siteConfiguration["manifestShortcuts{$i}Name"] ?? '',
                     'short_name' => $siteConfiguration["manifestShortcuts{$i}ShortName"] ?? '',
                     'description' => $siteConfiguration["manifestShortcuts{$i}Description"] ?? '',
                     'url' => $contentObject->typoLink_URL(['parameter' => $siteConfiguration["manifestShortcuts{$i}Url"] ?? '', 'forceAbsoluteUrl' => true]),
-                    'icons' => \array_filter([
-                        'src' => $siteConfiguration["manifestShortcuts{$i}IconSrc"] ?? '',
+                    'icons' => array_filter([
+                        'src' => $this->getPathForSrc($siteConfiguration["manifestShortcuts{$i}IconSrc"] ?? ''),
                         'sizes' => $siteConfiguration["manifestShortcuts{$i}IconSizes"] ?? ''
                     ])
                 ]);
@@ -89,21 +142,5 @@ class ConfigurationService
     protected function getExtensionConfiguration(): ExtensionConfiguration
     {
         return GeneralUtility::makeInstance(ExtensionConfiguration::class);
-    }
-
-    /**
-     * @return ServerRequest
-     */
-    protected function getServerRequest(): ServerRequest
-    {
-        return $GLOBALS['TYPO3_REQUEST'];
-    }
-
-    /**
-     * @return Site
-     */
-    protected function getSite(): Site
-    {
-        return $this->getServerRequest()->getAttribute('site');
     }
 }

--- a/Classes/Service/ConfigurationService.php
+++ b/Classes/Service/ConfigurationService.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\PwaManifest\Service;
 
 use Psr\Http\Message\ServerRequestInterface;
-use Symfony\Component\Config\Resource\FileResource;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Core\Environment;
-use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\CMS\Core\Resource\Exception\InvalidFileException;
 use TYPO3\CMS\Core\Resource\Exception\ResourceDoesNotExistException;
 use TYPO3\CMS\Core\Resource\Folder;
@@ -99,7 +96,7 @@ class ConfigurationService
         $resourceFactory = GeneralUtility::makeInstance(ResourceFactory::class);
         $file = $resourceFactory->retrieveFileOrFolderObject($src);
         // If the file is not found , we return an empty string
-        if($file === null || $file instanceof Folder) {
+        if ($file === null || $file instanceof Folder) {
             return '';
         }
         return $file->getPublicUrl();
@@ -125,10 +122,12 @@ class ConfigurationService
                     'short_name' => $siteConfiguration["manifestShortcuts{$i}ShortName"] ?? '',
                     'description' => $siteConfiguration["manifestShortcuts{$i}Description"] ?? '',
                     'url' => $contentObject->typoLink_URL(['parameter' => $siteConfiguration["manifestShortcuts{$i}Url"] ?? '', 'forceAbsoluteUrl' => true]),
-                    'icons' => array_filter([
-                        'src' => $this->getPathForSrc($siteConfiguration["manifestShortcuts{$i}IconSrc"] ?? ''),
-                        'sizes' => $siteConfiguration["manifestShortcuts{$i}IconSizes"] ?? ''
-                    ])
+                    'icons' => [
+                        array_filter([
+                            'src' => $this->getPathForSrc($siteConfiguration["manifestShortcuts{$i}IconSrc"] ?? ''),
+                            'sizes' => $siteConfiguration["manifestShortcuts{$i}IconSizes"] ?? ''
+                        ])
+                    ]
                 ]);
             }
         }

--- a/Configuration/Routes/Manifest.yaml
+++ b/Configuration/Routes/Manifest.yaml
@@ -1,0 +1,5 @@
+routeEnhancers:
+  PageTypeSuffix:
+    type: PageType
+    map:
+      'site.webmanifest': 835

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,22 +1,22 @@
 manifest = PAGE
 manifest {
-    typeNum = 835
-    config {
-        no_cache = 0
-        sendCacheHeaders = 1
-        debug = 0
-        admPanel = 0
-        disableAllHeaderCode = 1
-        additionalHeaders.10 {
-            header = Content-Type: application/json; charset=utf-8
-            replace = 1
-        }
+  typeNum = 835
+  config {
+    no_cache = 0
+    sendCacheHeaders = 1
+    debug = 0
+    admPanel = 0
+    disableAllHeaderCode = 1
+    additionalHeaders.10 {
+      header = Content-Type: application/json; charset=utf-8
+      replace = 1
     }
+  }
 
-    10 = USER
-    10 {
-        userFunc = FriendsOfTYPO3\PwaManifest\Service\ConfigurationService->provideConfiguration
-    }
+  10 = USER
+  10 {
+    userFunc = FriendsOfTYPO3\PwaManifest\Service\ConfigurationService->provideConfiguration
+  }
 }
 
 ##############
@@ -24,21 +24,16 @@ manifest {
 ##############
 page = PAGE
 page {
-    headerData {
-        198765 = TEXT
-        198765.value = <link rel="manifest" href="/?type=835">
+  headerData {
+    198765 = TEXT
+    198765.value = <link rel="manifest" href="/?type=835">
+  }
+
+  jsFooterInline {
+    198765 = TEXT
+    198765 {
+      data = path : EXT:pwa_manifest/Resources/Public/JavaScript/sw.js
+      wrap = if ('serviceWorker' in navigator) { window.addEventListener('load', function() { navigator.serviceWorker.register('/|'); }); }
     }
-    jsFooterInline {
-        198765 = COA
-        198765 {
-            10 = TEXT
-            10.value (
-                if ('serviceWorker' in navigator) {
-                  window.addEventListener('load', function() {
-                    navigator.serviceWorker.register('/typo3conf/ext/pwa_manifest/Public/Javascript/sw.js');
-                  });
-                }
-            )
-        }
-    }
+  }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -26,7 +26,16 @@ page = PAGE
 page {
   headerData {
     198765 = TEXT
-    198765.value = <link rel="manifest" href="/?type=835">
+    198765 {
+      value.typolink {
+        parameter = 1
+        additionalParams = &type=835
+        returnLast = url
+      }
+      wrap = <link rel="manifest" href="|">
+    }
+
+
   }
 
   jsFooterInline {

--- a/Resources/Public/JavaScript/sw.js
+++ b/Resources/Public/JavaScript/sw.js
@@ -1,12 +1,11 @@
-importScripts('https://cdn.jsdelivr.net/npm/workbox-cdn@4.3.1/workbox/workbox-sw.js')
-
+importScripts('https://cdn.jsdelivr.net/npm/workbox-cdn@5.1.4/workbox/workbox-sw.min.js');
 // --------------------------------------------------
 // Configure
 // --------------------------------------------------
 
 // Set workbox config
 workbox.setConfig({
-    "debug": false
+  "debug": false
 })
 
 // Start controlling any existing clients as soon as it activates
@@ -28,5 +27,5 @@ workbox.precaching.cleanupOutdatedCaches()
 // --------------------------------------------------
 
 // Register route handlers for runtimeCaching
-workbox.routing.registerRoute(new RegExp('/fileadmin/.*'), new workbox.strategies.NetworkFirst ({"cacheName":"assets-cache","maxAgeSeconds":86400}), 'GET')
-workbox.routing.registerRoute(new RegExp('/'), new workbox.strategies.NetworkFirst ({}), 'GET')
+workbox.routing.registerRoute(new RegExp('/fileadmin/.*'), new workbox.strategies.NetworkFirst({"cacheName": "assets-cache", "maxAgeSeconds": 86400}), 'GET')
+workbox.routing.registerRoute(new RegExp('/'), new workbox.strategies.NetworkFirst({}), 'GET')

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^12.0"
+    "typo3/cms-core": "^12.4 || ^13.4"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.13"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,11 +8,10 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'extensions@macopedia.pl',
     'category' => 'fe',
     'internal' => '',
-    'version' => '2.0.0',
+    'version' => '2.1.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.0.0-12.4.99',
-            'frontend' => '12.0.0-12.4.99'
+            'typo3' => '12.4.0-13.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
### Changes

1. Update ConfigurationService to use EXT: Paths #22 and switch to the TYPO3 Request-API
2. Rewrite of the ServiceWorker include so that the new /_assets/ pathing is working in TYPO3 v12 #20 
3. Move the sw.js to the proper TYPO3 folder structure 
4. Update workbox-cdn to 5.1